### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A library management tool written for iOS platform.
 **Database:** [Sqlite](https://sqlite.org/cli.html).
 
 ## Features
-This program is based on MVC structure and it is designed to support 3 different user groups:
+This program is based on MVC structure and supports 3 different user groups:
 
 **Librarian:** Librarians can view, search and manage books.
 
@@ -17,8 +17,8 @@ This program is based on MVC structure and it is designed to support 3 different
 
 ## Build
 
-- Clone/download the repo
+- Clone the repo
 ```bash
 git clone https://github.com/jerryljq/Syrah-Library-For-iPad
 ```
-- Import this project in Xcode to demo. [(How)](https://help.dropsource.com/docs/documentation/after-dropsource/accessing-your-source-code/importing-ios-source-code-into-xcode/)
+- [Import this project to Xcode](https://help.dropsource.com/docs/documentation/after-dropsource/accessing-your-source-code/importing-ios-source-code-into-xcode/) for demo.


### PR DESCRIPTION
Changed “Clone/download the repo” -> "Clone the repo". The command given below is how to clone. It's confusing to include download here.
Integrate the "how to" link into the text.
Removed redundancies.